### PR TITLE
Include CHANGELOG.md in long_description metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':  # Do not run setup() when we import this module.
         name=NAME,
         version='<version>',
         description=DESCRIPTION,
+        long_description=open("CHANGELOG.md").read(),
         keywords=' '.join(KEYWORDS),
         author=AUTHOR,
         author_email=EMAIL,


### PR DESCRIPTION
Can we do an experiment to see if the content from CHANGELOG.md is correctly rendered on the outsystems-pipeline package page? If it works, it's an easy way to populate the page for now.