### PR TITLE
Update pipeline_vars.py

### DIFF
--- a/outsystems/vars/pipeline_vars.py
+++ b/outsystems/vars/pipeline_vars.py
@@ -1,7 +1,7 @@
 # Deployment specific variables
 QUEUE_TIMEOUT_IN_SECS = 1800
 DEPLOYMENT_TIMEOUT_IN_SECS = 14400
-SLEEP_PERIOD_IN_SECS = 20
+SLEEP_PERIOD_IN_SECS = 60
 REDEPLOY_OUTDATED_APPS = True
 DEPLOYMENT_STATUS_LIST = ["saved", "running", "needs_user_intervention", "aborting"]
 DEPLOYMENT_ERROR_STATUS_LIST = ["aborted", "finished_with_errors"]

--- a/outsystems/vars/pipeline_vars.py
+++ b/outsystems/vars/pipeline_vars.py
@@ -1,6 +1,6 @@
 # Deployment specific variables
 QUEUE_TIMEOUT_IN_SECS = 1800
-DEPLOYMENT_TIMEOUT_IN_SECS = 3600
+DEPLOYMENT_TIMEOUT_IN_SECS = 14400
 SLEEP_PERIOD_IN_SECS = 20
 REDEPLOY_OUTDATED_APPS = True
 DEPLOYMENT_STATUS_LIST = ["saved", "running", "needs_user_intervention", "aborting"]


### PR DESCRIPTION
Our environment has 70+ applications and a publish takes about 2 to 3 hours, a 1 hour timeout is to short for this.
Please consider this change.