### PR TITLE
Update evaluate_test_results.py

### DIFF
--- a/outsystems/pipeline/evaluate_test_results.py
+++ b/outsystems/pipeline/evaluate_test_results.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
         setattr(BDDTestRunner, test_name, test_func)
 
     # Runs the test suite and stores the value in a XMN file to be used by JUNIT
-    filename = os.path.join(ARTIFACT_FOLDER, JUNIT_TEST_RESULTS_FILE)
+    filename = os.path.join(artifact_dir, JUNIT_TEST_RESULTS_FILE)
     try:
         with open(filename, 'wb') as output:
             runner = xmlrunner.XMLTestRunner(output=output, failfast=False, buffer=False)


### PR DESCRIPTION
Fixed artifact_dir not used in filename path.